### PR TITLE
JMK_48: use freelancer_id instead of user_id for freelancer

### DIFF
--- a/src/main/java/com/jobmatrix/dto/CertificateDTO.java
+++ b/src/main/java/com/jobmatrix/dto/CertificateDTO.java
@@ -19,5 +19,5 @@ public class CertificateDTO {
     private Date issueDate;
     private Date expiryDate;
     private String credentialUrl;
-    private UUID userId;
+    private UUID freelancerId;
 }

--- a/src/main/java/com/jobmatrix/dto/JobDTO.java
+++ b/src/main/java/com/jobmatrix/dto/JobDTO.java
@@ -19,5 +19,5 @@ public class JobDTO {
     private Date startDate;
     private Date endDate;
     private String jobResponsibilities;
-    private UUID userId;
+    private UUID freelancerId;
 }

--- a/src/main/java/com/jobmatrix/entity/Certificate.java
+++ b/src/main/java/com/jobmatrix/entity/Certificate.java
@@ -47,6 +47,6 @@ public class Certificate {
     private Timestamp updatedAt;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "user_id", insertable = false, updatable = false)
+    @JoinColumn(name = "freelancer_id", referencedColumnName = "freelancer_id", insertable = false, updatable = false)
     private Freelancer freelancer;
 }

--- a/src/main/java/com/jobmatrix/entity/Education.java
+++ b/src/main/java/com/jobmatrix/entity/Education.java
@@ -37,8 +37,8 @@ public class Education {
     @Column(name = "end_year")
     private Integer endYear;
 
-    @Column(name = "user_id")
-    private UUID userId;
+    @Column(name = "freelancer_id")
+    private UUID freelancerId;
 
     @Column(name = "created_at")
     private Timestamp createdAt;
@@ -47,6 +47,6 @@ public class Education {
     private Timestamp updatedAt;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "user_id", insertable = false, updatable = false)
+    @JoinColumn(name = "freelancer_id", referencedColumnName = "freelancer_id", insertable = false, updatable = false)
     private Freelancer freelancer;
 }

--- a/src/main/java/com/jobmatrix/entity/Freelancer.java
+++ b/src/main/java/com/jobmatrix/entity/Freelancer.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 public class Freelancer {
 
     @Id
-    @Column(nullable = false, name = "user_id", updatable = false)
+    @Column(nullable = false, name = "freelancer_id", updatable = false)
     private UUID freelancerId;
 
     @Column(name = "title")

--- a/src/main/java/com/jobmatrix/entity/Job.java
+++ b/src/main/java/com/jobmatrix/entity/Job.java
@@ -37,8 +37,8 @@ public class Job {
     @Column(name = "job_responsibilities")
     private String jobResponsibilities;
 
-    @Column(name = "user_id")
-    private UUID userId;
+    @Column(name = "freelancer_id")
+    private UUID freelancerId;
 
     @Column(name = "created_at")
     private Timestamp createdAt;
@@ -47,6 +47,6 @@ public class Job {
     private Timestamp updatedAt;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "user_id", insertable = false, updatable = false)
+    @JoinColumn(name = "freelancer_id", referencedColumnName = "freelancer_id", insertable = false, updatable = false)
     private Freelancer freelancer;
 }

--- a/src/test/java/com/jobmatrix/dto/CertificateDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/CertificateDTOTest.java
@@ -29,7 +29,7 @@ class CertificateDTOTest {
         assertNull(dto.getIssueDate());
         assertNull(dto.getExpiryDate());
         assertNull(dto.getCredentialUrl());
-        assertNull(dto.getUserId());
+        assertNull(dto.getFreelancerId());
     }
 
     @Test
@@ -50,7 +50,7 @@ class CertificateDTOTest {
         assertEquals(issueDate, dto.getIssueDate());
         assertEquals(expiryDate, dto.getExpiryDate());
         assertEquals(credentialUrl, dto.getCredentialUrl());
-        assertEquals(userId, dto.getUserId());
+        assertEquals(userId, dto.getFreelancerId());
     }
 
     @Test
@@ -69,7 +69,7 @@ class CertificateDTOTest {
         certificateDTO.setIssueDate(issueDate);
         certificateDTO.setExpiryDate(expiryDate);
         certificateDTO.setCredentialUrl(credentialUrl);
-        certificateDTO.setUserId(userId);
+        certificateDTO.setFreelancerId(userId);
 
         assertEquals(certificateId, certificateDTO.getCertificateId());
         assertEquals(certificateName, certificateDTO.getCertificateName());
@@ -77,7 +77,7 @@ class CertificateDTOTest {
         assertEquals(issueDate, certificateDTO.getIssueDate());
         assertEquals(expiryDate, certificateDTO.getExpiryDate());
         assertEquals(credentialUrl, certificateDTO.getCredentialUrl());
-        assertEquals(userId, certificateDTO.getUserId());
+        assertEquals(userId, certificateDTO.getFreelancerId());
     }
 
     @Test
@@ -108,8 +108,8 @@ class CertificateDTOTest {
     void testUUIDHandling() {
         UUID uuid1 = UUID.randomUUID();
 
-        certificateDTO.setUserId(uuid1);
-        assertEquals(uuid1, certificateDTO.getUserId());
+        certificateDTO.setFreelancerId(uuid1);
+        assertEquals(uuid1, certificateDTO.getFreelancerId());
     }
 
     @Test

--- a/src/test/java/com/jobmatrix/dto/JobDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/JobDTOTest.java
@@ -50,7 +50,7 @@ class JobDTOTest {
         assertNull(emptyJobDTO.getStartDate());
         assertNull(emptyJobDTO.getEndDate());
         assertNull(emptyJobDTO.getJobResponsibilities());
-        assertNull(emptyJobDTO.getUserId());
+        assertNull(emptyJobDTO.getFreelancerId());
     }
 
     @Test
@@ -74,7 +74,7 @@ class JobDTOTest {
         assertEquals(TEST_START_DATE, jobDTO.getStartDate());
         assertEquals(TEST_END_DATE, jobDTO.getEndDate());
         assertEquals(TEST_JOB_RESPONSIBILITIES, jobDTO.getJobResponsibilities());
-        assertEquals(TEST_USER_ID, jobDTO.getUserId());
+        assertEquals(TEST_USER_ID, jobDTO.getFreelancerId());
     }
 
     @Test
@@ -141,20 +141,20 @@ class JobDTOTest {
     @DisplayName("Test UserId Getter and Setter")
     void testUserIdGetterAndSetter() {
         // Act
-        jobDTO.setUserId(TEST_USER_ID);
+        jobDTO.setFreelancerId(TEST_USER_ID);
 
         // Assert
-        assertEquals(TEST_USER_ID, jobDTO.getUserId());
+        assertEquals(TEST_USER_ID, jobDTO.getFreelancerId());
     }
 
     @Test
     @DisplayName("Test UserId with Mocked UUID")
     void testUserIdWithMockedUUID() {
         // Act
-        jobDTO.setUserId(mockUserId);
+        jobDTO.setFreelancerId(mockUserId);
 
         // Assert
-        assertEquals(mockUserId, jobDTO.getUserId());
+        assertEquals(mockUserId, jobDTO.getFreelancerId());
         verifyNoInteractions(mockUserId); // Verify the mock was not interacted with
     }
 


### PR DESCRIPTION
Currently, API endpoint call to create freelancer profile will fail since we still have user_id references in some of the files. Using this PR to rename user_id to freelancer_id. 