### PR TITLE
JMK_56: enable CORS support, update swagger version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version>
+			<version>2.8.6</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/jobmatrix/JmProfileManagementApplication.java
+++ b/src/main/java/com/jobmatrix/JmProfileManagementApplication.java
@@ -1,10 +1,13 @@
 package com.jobmatrix;
 
+import com.common.config.CorsConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import(CorsConfig.class)
 @EntityScan(basePackages = {"com.jobmatrix", "com.common.entity"})
 public class JmProfileManagementApplication {
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+cors.allowed-origins=http://localhost:5173,http://localhost:5174,http://localhost:5175

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,1 +1,1 @@
-cors.allowed-origins=http://localhost:5173,http://localhost:5174,http://localhost:5175
+cors.allowed-origins=https://dev/jobmatrix.com

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,1 @@
+cors.allowed-origins=http://localhost:5173,http://localhost:5174,http://localhost:5175

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,1 @@
+cors.allowed-origins=https://jobmatrix.com

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.jpa.hibernate.ddl-auto = validate
 spring.jpa.show-sql = true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.hikari.maximum-pool-size = 10
+
+spring.profiles.active=dev

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,4 @@ spring.jpa.show-sql = true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.hikari.maximum-pool-size = 10
 
-spring.profiles.active=dev
+spring.profiles.active=local


### PR DESCRIPTION
Enabled CORS support in the jm-profile-management service by importing the shared CorsConfig from jm-common.
Updated Swagger version for better compatibility and documentation improvements.
