### PR TITLE
Feature/JMK_96: Added a mapping of services to category_id for a specific freelancer_id in POST /create_profile

### DIFF
--- a/src/main/java/com/jobmatrix/config/ModelMapperConfig.java
+++ b/src/main/java/com/jobmatrix/config/ModelMapperConfig.java
@@ -1,5 +1,8 @@
 package com.jobmatrix.config;
 
+import java.util.UUID;
+import org.modelmapper.AbstractConverter;
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +12,27 @@ public class ModelMapperConfig {
 
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        ModelMapper modelMapper = new ModelMapper();
+        
+        // Add custom converter for UUID to Long conversion
+        Converter<UUID, Long> uuidToLongConverter = new AbstractConverter<UUID, Long>() {
+            @Override
+            protected Long convert(UUID source) {
+                return null; // Return null for UUID to Long conversion
+            }
+        };
+        
+        // Add custom converter for Long to UUID conversion
+        Converter<Long, UUID> longToUuidConverter = new AbstractConverter<Long, UUID>() {
+            @Override
+            protected UUID convert(Long source) {
+                return null; // Return null for Long to UUID conversion
+            }
+        };
+        
+        modelMapper.addConverter(uuidToLongConverter);
+        modelMapper.addConverter(longToUuidConverter);
+        
+        return modelMapper;
     }
 }

--- a/src/main/java/com/jobmatrix/entity/FreelancerService.java
+++ b/src/main/java/com/jobmatrix/entity/FreelancerService.java
@@ -1,0 +1,24 @@
+package com.jobmatrix.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.util.UUID;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+@Entity
+@Table(name = "freelancer_services")
+public class FreelancerService {
+
+    @EmbeddedId
+    private FreelancerServiceKey id;
+
+}

--- a/src/main/java/com/jobmatrix/entity/FreelancerServiceKey.java
+++ b/src/main/java/com/jobmatrix/entity/FreelancerServiceKey.java
@@ -1,0 +1,21 @@
+package com.jobmatrix.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+@Embeddable
+public class FreelancerServiceKey {
+
+    private UUID freelancerId;
+    private Long categoryId;
+
+}

--- a/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandler.java
@@ -27,4 +27,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleClientNotFoundException(ClientNotFoundException ex){
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
+
+    @ExceptionHandler(ServiceLimitExceededException.class)
+    public ResponseEntity<String> handleServiceLimitExceeded(ServiceLimitExceededException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/jobmatrix/exceptionHandling/ServiceLimitExceededException.java
+++ b/src/main/java/com/jobmatrix/exceptionHandling/ServiceLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.jobmatrix.exceptionHandling;
+
+public class ServiceLimitExceededException extends RuntimeException {
+    public ServiceLimitExceededException() {
+        super("Cannot assign more than 10 services.");
+    }
+}

--- a/src/main/java/com/jobmatrix/repository/FreelancerServicesRepository.java
+++ b/src/main/java/com/jobmatrix/repository/FreelancerServicesRepository.java
@@ -1,0 +1,27 @@
+package com.jobmatrix.repository;
+
+
+import com.jobmatrix.entity.FreelancerService;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FreelancerServicesRepository extends JpaRepository<FreelancerService, Long> {
+
+    @Query("SELECT fs FROM FreelancerService fs WHERE fs.id.freelancerId = :freelancerId")
+    List<FreelancerService> findByFreelancerId_FreelancerId(@Param("freelancerId") UUID freelancerId);
+
+    /*
+So what's happening in the code below is that whenever we are using this POST method for that particular freelancerId, it will delete all the services that are associated with that freelancerId and will again add it. Sounds like a PUT method. For example some freelancer has 3 services and he wants to add 2 more services, so we will delete all the previous services and add the new ones. So it will be like a PUT method. Like it will now add all the 5 data in the database again. (This comment is just for clarification purpose. Can be removed later if not needed.)
+*/
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM FreelancerService fs WHERE fs.id.freelancerId = :freelancerId")
+    void deleteByFreelancerId(@Param("freelancerId") UUID freelancerId);
+
+}

--- a/src/main/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImpl.java
@@ -4,6 +4,7 @@ import com.common.dto.FreelancerDTO;
 import com.common.entity.Freelancer;
 import com.jobmatrix.entity.FreelancerService;
 import com.jobmatrix.entity.FreelancerServiceKey;
+import com.jobmatrix.exceptionHandling.ServiceLimitExceededException;
 import com.jobmatrix.repository.FreelancerRepository;
 import com.jobmatrix.repository.FreelancerServicesRepository;
 import com.jobmatrix.service.FreelancerProfileService;
@@ -17,7 +18,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.UUID;
-
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +36,14 @@ public class FreelancerProfileServiceImpl implements FreelancerProfileService {
             throw new IllegalArgumentException("FreelancerDTO cannot be null");
         }
         
+        // Check service limit BEFORE saving the freelancer
+        if (freelancerDTO.getServices() != null && !freelancerDTO.getServices().isEmpty()) {
+            // Check if services exceed allowed limit
+            if (freelancerDTO.getServices().size() > 10) {
+                throw new ServiceLimitExceededException();
+            }
+        }
+
         // Save freelancer first to get the generated ID
         Freelancer freelancer = freelancerRepository.save(modelMapper.map(freelancerDTO, Freelancer.class));
         UUID freelancerId = freelancer.getFreelancerId();

--- a/src/main/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImpl.java
@@ -2,13 +2,21 @@ package com.jobmatrix.serviceimpl;
 
 import com.common.dto.FreelancerDTO;
 import com.common.entity.Freelancer;
+import com.jobmatrix.entity.FreelancerService;
+import com.jobmatrix.entity.FreelancerServiceKey;
 import com.jobmatrix.repository.FreelancerRepository;
+import com.jobmatrix.repository.FreelancerServicesRepository;
 import com.jobmatrix.service.FreelancerProfileService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.log4j.Logger;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.UUID;
 
 
 @Service
@@ -18,12 +26,40 @@ public class FreelancerProfileServiceImpl implements FreelancerProfileService {
     private static final Logger logger = Logger.getLogger(FreelancerProfileServiceImpl.class);
     private final ModelMapper modelMapper;
     private final FreelancerRepository freelancerRepository;
+    private final FreelancerServicesRepository freelancerServiceRepository;
 
     @Override
     @Transactional
     public Freelancer createFreelancerProfile(FreelancerDTO freelancerDTO) {
+        // Validate input
+        if (freelancerDTO == null) {
+            throw new IllegalArgumentException("FreelancerDTO cannot be null");
+        }
+        
+        // Save freelancer first to get the generated ID
         Freelancer freelancer = freelancerRepository.save(modelMapper.map(freelancerDTO, Freelancer.class));
-        logger.info("Freelancer profile created successfully with id: " + freelancer.getFreelancerId());
+        UUID freelancerId = freelancer.getFreelancerId();
+        
+        // Map services (category IDs) if provided
+        if (freelancerDTO.getServices() != null && !freelancerDTO.getServices().isEmpty()) {
+            // Delete existing services for this freelancer first
+            freelancerServiceRepository.deleteByFreelancerId(freelancerId);
+            
+            // Sort category IDs in ascending order
+            List<Long> sortedCategories = freelancerDTO.getServices()
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .sorted()
+                    .collect(Collectors.toList());
+            
+            for (Long categoryId : sortedCategories) {
+                FreelancerService mapping = new FreelancerService();
+                mapping.setId(new FreelancerServiceKey(freelancerId, categoryId));
+                freelancerServiceRepository.save(mapping);
+            }
+        }
+
+        logger.info("Freelancer profile created successfully with id: " + freelancerId);
         return freelancer;
     }
 }

--- a/src/test/java/com/jobmatrix/dto/CertificateDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/CertificateDTOTest.java
@@ -24,7 +24,6 @@ class CertificateDTOTest {
     @Test
     void testDefaultConstructor() {
         CertificateDTO dto = new CertificateDTO();
-        assertNull(dto.getCertificateId());
         assertNull(dto.getCertificateName());
         assertNull(dto.getIssuedBy());
         assertNull(dto.getIssueDate());
@@ -43,9 +42,8 @@ class CertificateDTOTest {
         String credentialUrl = "https://example.com/cert";
         UUID userId = UUID.randomUUID();
 
-        CertificateDTO dto = new CertificateDTO(certificateId, certificateName, issuedBy, issueDate, expiryDate, credentialUrl, userId);
+        CertificateDTO dto = new CertificateDTO(certificateName, issuedBy, issueDate, expiryDate, credentialUrl, userId);
 
-        assertEquals(certificateId, dto.getCertificateId());
         assertEquals(certificateName, dto.getCertificateName());
         assertEquals(issuedBy, dto.getIssuedBy());
         assertEquals(issueDate, dto.getIssueDate());
@@ -64,7 +62,6 @@ class CertificateDTOTest {
         String credentialUrl = "https://google.com/cert";
         UUID userId = UUID.randomUUID();
 
-        certificateDTO.setCertificateId(certificateId);
         certificateDTO.setCertificateName(certificateName);
         certificateDTO.setIssuedBy(issuedBy);
         certificateDTO.setIssueDate(issueDate);
@@ -72,7 +69,6 @@ class CertificateDTOTest {
         certificateDTO.setCredentialUrl(credentialUrl);
         certificateDTO.setFreelancerId(userId);
 
-        assertEquals(certificateId, certificateDTO.getCertificateId());
         assertEquals(certificateName, certificateDTO.getCertificateName());
         assertEquals(issuedBy, certificateDTO.getIssuedBy());
         assertEquals(issueDate, certificateDTO.getIssueDate());

--- a/src/test/java/com/jobmatrix/dto/EducationDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/EducationDTOTest.java
@@ -26,7 +26,6 @@ class EducationDTOTest {
         validator = factory.getValidator();
 
         educationDTO = new EducationDTO(
-                1L,
                 "B.Tech",
                 "Computer Science",
                 "Thapar University",
@@ -43,15 +42,7 @@ class EducationDTOTest {
         assertTrue(violations.isEmpty(), "No validation errors expected for valid EducationDTO.");
     }
 
-    //  educationId should not be null
-    @Test
-    void testEducationId_Null() {
-        educationDTO.setEducationId(null);
-        Set<ConstraintViolation<EducationDTO>> violations = validator.validate(educationDTO);
 
-        assertEquals(1, violations.size(), "Expected 1 validation error for null educationId.");
-        assertEquals("educationId cannot be null.", violations.iterator().next().getMessage());
-    }
 
     //  degree should not be blank
     @Test

--- a/src/test/java/com/jobmatrix/dto/FreelancerDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/FreelancerDTOTest.java
@@ -9,6 +9,7 @@ import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
 
@@ -58,6 +59,7 @@ public class FreelancerDTOTest {
         freelancerDTO.setTitle("");
         Set<ConstraintViolation<FreelancerDTO>> violations = validator.validate(freelancerDTO);
         assertEquals(1, violations.size(), "Expected 1 validation error for empty title");
+        assertEquals("title cannot be empty.", violations.iterator().next().getMessage());
     }
 
     // Negative Case: Invalid postal code (less than 6 digits)
@@ -96,12 +98,42 @@ public class FreelancerDTOTest {
     }
 
 
+    // Service-related test cases
+    @Test
+    public void testFreelancerDTO_Services_Empty() {
+        freelancerDTO.setServices(Arrays.asList());
+        Set<ConstraintViolation<FreelancerDTO>> violations = validator.validate(freelancerDTO);
+        assertTrue(violations.isEmpty(), "Services can be empty, validation should pass");
+    }
+
+    @Test
+    public void testFreelancerDTO_Services_InvalidId() {
+        freelancerDTO.setServices(Arrays.asList(-1L, 0L));
+        Set<ConstraintViolation<FreelancerDTO>> violations = validator.validate(freelancerDTO);
+        assertTrue(violations.isEmpty(), "Service IDs validation not implemented, validation should pass");
+    }
+
+    @Test
+    public void testFreelancerDTO_Services_Unsorted() {
+        freelancerDTO.setServices(Arrays.asList(5L, 2L, 8L, 1L, 3L));
+        Set<ConstraintViolation<FreelancerDTO>> violations = validator.validate(freelancerDTO);
+        assertTrue(violations.isEmpty(), "Services sorting validation not implemented, validation should pass");
+    }
+
+    @Test
+    public void testFreelancerDTO_Services_Valid() {
+        freelancerDTO.setServices(Arrays.asList(1L, 2L, 3L, 4L, 5L));
+        Set<ConstraintViolation<FreelancerDTO>> violations = validator.validate(freelancerDTO);
+        assertTrue(violations.isEmpty(), "Validation should pass for valid services");
+    }
+
     // Negative Case: Invalid postal code (more than 6 digits)
     @Test
     public void testFreelancerDTO_PostalCode_TooLong() {
         freelancerDTO.setPostalCode("1234567");
         Set<ConstraintViolation<FreelancerDTO>> violations = validator.validate(freelancerDTO);
         assertEquals(1, violations.size(), "Expected 1 validation error for invalid postal code (too long)");
+        assertEquals("Please enter a valid postal code", violations.iterator().next().getMessage());
     }
 
     // Negative Case: Invalid phone number (not starting with 6-9)

--- a/src/test/java/com/jobmatrix/dto/JobDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/JobDTOTest.java
@@ -41,7 +41,6 @@ class JobDTOTest {
 
         // Assert
         assertNotNull(emptyJobDTO);
-        assertNull(emptyJobDTO.getJobId());
         assertNull(emptyJobDTO.getJobTitle());
         assertNull(emptyJobDTO.getCompanyName());
         assertNull(emptyJobDTO.getStartDate());
@@ -55,7 +54,6 @@ class JobDTOTest {
     void testAllArgsConstructor() {
         // Arrange & Act
         JobDTO jobDTO = new JobDTO(
-                TEST_JOB_ID,
                 TEST_JOB_TITLE,
                 TEST_COMPANY_NAME,
                 TEST_START_DATE,
@@ -65,7 +63,6 @@ class JobDTOTest {
         );
 
         // Assert
-        assertEquals(TEST_JOB_ID, jobDTO.getJobId());
         assertEquals(TEST_JOB_TITLE, jobDTO.getJobTitle());
         assertEquals(TEST_COMPANY_NAME, jobDTO.getCompanyName());
         assertEquals(TEST_START_DATE, jobDTO.getStartDate());
@@ -74,15 +71,6 @@ class JobDTOTest {
         assertEquals(TEST_USER_ID, jobDTO.getFreelancerId());
     }
 
-    @Test
-    @DisplayName("Test JobId Getter and Setter")
-    void testJobIdGetterAndSetter() {
-        // Act
-        jobDTO.setJobId(TEST_JOB_ID);
-
-        // Assert
-        assertEquals(TEST_JOB_ID, jobDTO.getJobId());
-    }
 
     @Test
     @DisplayName("Test JobTitle Getter and Setter")

--- a/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jobmatrix/exceptionHandling/GlobalExceptionHandlerTest.java
@@ -1,23 +1,31 @@
 package com.jobmatrix.exceptionHandling;
 
+import com.common.dto.FreelancerDTO;
 import com.common.exceptionHandling.ClientNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jobmatrix.controller.ClientProfileController;
 import com.jobmatrix.dto.ClientDTO;
 import com.jobmatrix.service.ClientProfileService;
+import com.jobmatrix.service.FreelancerProfileService;
 import com.jobmatrix.test_utils.factory.ClientTestDataFactory;
+import com.jobmatrix.test_utils.factory.FreelancerTestDataFactory;
+import org.mockito.Mock;
+import org.modelmapper.ModelMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import java.util.List;
 import java.util.UUID;
 
-@WebMvcTest(ClientProfileController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GlobalExceptionHandlerTest {
 
     @Autowired
@@ -26,10 +34,16 @@ class GlobalExceptionHandlerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockitoBean
+    @Mock
+    private ModelMapper modelMapper;
+    @Mock
     private ClientProfileService clientProfileService;
+    @Mock
+    private FreelancerProfileService freelancerProfileService;
 
     private final UUID CLIENT_ID = UUID.randomUUID();
+
+
 
     @Test
     void shouldReturnValidationErrors_whenInvalidInputGiven() throws Exception {
@@ -63,4 +77,21 @@ class GlobalExceptionHandlerTest {
                 .andExpect(MockMvcResultMatchers.content().string("Client not found with ID: " + CLIENT_ID));
     }
 
+    @Test
+    void shouldReturnServiceLimitExceeded_whenTooManyServicesProvided() throws Exception {
+        // Create a valid DTO using factory and add too many services
+        FreelancerDTO freelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(UUID.randomUUID());
+        freelancerDTO.setServices(List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L));
+
+        // Mock the service to throw ServiceLimitExceededException
+        Mockito.when(freelancerProfileService.createFreelancerProfile(Mockito.any(FreelancerDTO.class)))
+                .thenThrow(new ServiceLimitExceededException());
+
+        // Send a POST request with too many services
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/freelancer/create_profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(freelancerDTO)))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.content().string("Cannot assign more than 10 services."));
+    }
 }

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -2,7 +2,9 @@ package com.jobmatrix.serviceimpl;
 
 import com.common.dto.FreelancerDTO;
 import com.common.entity.Freelancer;
+import com.jobmatrix.entity.FreelancerService;
 import com.jobmatrix.repository.FreelancerRepository;
+import com.jobmatrix.repository.FreelancerServicesRepository;
 import com.jobmatrix.test_utils.factory.FreelancerTestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,6 +29,8 @@ class FreelancerProfileServiceImplTest {
 
     @Mock
     private ModelMapper modelMapper;
+    @Mock
+    private FreelancerServicesRepository freelancerServiceRepository;
 
     @InjectMocks
     private FreelancerProfileServiceImpl freelancerProfileService;
@@ -43,14 +48,18 @@ class FreelancerProfileServiceImplTest {
 
     @Test
     void saveFreelancerProfile_shouldSaveAndReturnFreelancerEntity() {
-
+        // Mock model mapping
         when(modelMapper.map(inputFreelancerDTO, Freelancer.class)).thenReturn(freelancerEntity);
+        
+        // Mock repository save
         when(freelancerRepository.save(any(Freelancer.class))).thenReturn(freelancerEntity);
 
+        // Execute the service method
         Freelancer result = freelancerProfileService.createFreelancerProfile(inputFreelancerDTO);
 
-        assertNotNull(result);
-        assertEquals(freelancerEntity.getFreelancerId(), result.getFreelancerId());
+        // Verify the result
+        assertNotNull(result, "Result should not be null");
+        assertEquals(freelancerEntity.getFreelancerId(), result.getFreelancerId() );
         assertEquals(freelancerEntity.getTitle(), result.getTitle());
         assertEquals(freelancerEntity.getBio(), result.getBio());
         assertEquals(freelancerEntity.getHourlyRate(), result.getHourlyRate());
@@ -60,15 +69,41 @@ class FreelancerProfileServiceImplTest {
         assertEquals(freelancerEntity.getCountry(), result.getCountry());
         assertEquals(freelancerEntity.getPostalCode(), result.getPostalCode());
         assertEquals(freelancerEntity.getPhoneNumber(), result.getPhoneNumber());
-        assertEquals(freelancerEntity.isAbcMember(), result.isAbcMember());
+        assertEquals(freelancerEntity.getIsAbcMember(), result.getIsAbcMember());
         assertEquals(freelancerEntity.getProfilePhotoURL(), result.getProfilePhotoURL());
         assertEquals(freelancerEntity.getProfileStatus(), result.getProfileStatus());
         assertNotNull(result.getCreatedAt());
         assertNotNull(result.getUpdatedAt());
 
-        verify(modelMapper).map(inputFreelancerDTO, Freelancer.class);
+        // Verify interactions
+        verify(modelMapper, times(1)).map(inputFreelancerDTO, Freelancer.class);
         verify(freelancerRepository, times(1)).save(any(Freelancer.class));
+        verifyNoMoreInteractions(freelancerRepository);
+        verifyNoMoreInteractions(modelMapper);
     }
+
+    @Test
+    void saveFreelancerProfile_withServices_shouldSaveServicesInSortedOrder() {
+        // Setup services with unsorted order
+        List<Long> unsortedServices = List.of(3L, 1L, 2L);
+        inputFreelancerDTO.setServices(unsortedServices);
+
+        when(modelMapper.map(inputFreelancerDTO, Freelancer.class)).thenReturn(freelancerEntity);
+        when(freelancerRepository.save(any(Freelancer.class))).thenReturn(freelancerEntity);
+        
+        // Mock repository methods
+        doNothing().when(freelancerServiceRepository).deleteByFreelancerId(FREELANCER_ID);
+        
+        Freelancer result = freelancerProfileService.createFreelancerProfile(inputFreelancerDTO);
+
+        assertNotNull(result);
+        
+        // Verify service deletion and saving
+        verify(freelancerServiceRepository).deleteByFreelancerId(FREELANCER_ID);
+        verify(freelancerServiceRepository, times(3)).save(any(FreelancerService.class));
+        verifyNoMoreInteractions(freelancerServiceRepository);
+    }
+
 
     @Test
     void saveFreelancerProfile_freelancerIdShouldNotBeNull() {

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -3,6 +3,7 @@ package com.jobmatrix.serviceimpl;
 import com.common.dto.FreelancerDTO;
 import com.common.entity.Freelancer;
 import com.jobmatrix.entity.FreelancerService;
+import com.jobmatrix.exceptionHandling.ServiceLimitExceededException;
 import com.jobmatrix.repository.FreelancerRepository;
 import com.jobmatrix.repository.FreelancerServicesRepository;
 import com.jobmatrix.test_utils.factory.FreelancerTestDataFactory;
@@ -116,6 +117,18 @@ class FreelancerProfileServiceImplTest {
                 "freelancer_id cannot be null."
         );
         assertEquals("freelancer_id cannot be null.", exception.getMessage());
+        verify(freelancerRepository, never()).save(any(Freelancer.class));
+    }
+
+    @Test
+    void saveFreelancerProfile_shouldThrowServiceLimitExceededException() {
+        // Setup input with more than 10 services
+        List<Long> services = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+        inputFreelancerDTO.setServices(services);
+
+        // Execute and verify exception
+        assertThrows(ServiceLimitExceededException.class, () -> freelancerProfileService.createFreelancerProfile(inputFreelancerDTO));
+
         verify(freelancerRepository, never()).save(any(Freelancer.class));
     }
 

--- a/src/test/java/com/jobmatrix/test_utils/factory/FreelancerTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/FreelancerTestDataFactory.java
@@ -72,7 +72,7 @@ public class FreelancerTestDataFactory {
 
     private static List<EducationDTO> createEducationListDTO(UUID freelancerId) {
         return Arrays.asList(
-                new EducationDTO(1L, "B.Tech", "Computer Science", "IIT Delhi", 2015, 2019, freelancerId)
+                new EducationDTO("B.Tech", "Computer Science", "IIT Delhi", 2015, 2019, freelancerId)
         );
     }
 
@@ -85,7 +85,7 @@ public class FreelancerTestDataFactory {
 
     private static List<JobDTO> createJobListDTO(UUID freelancerId) {
         return Arrays.asList(
-                new JobDTO(1L, "Software Engineer", "Google", Date.valueOf("2020-01-01"), Date.valueOf("2023-06-01"),
+                new JobDTO("Software Engineer", "Google", Date.valueOf("2020-01-01"), Date.valueOf("2023-06-01"),
                         "Developed scalable backend systems", freelancerId)
         );
     }
@@ -99,7 +99,7 @@ public class FreelancerTestDataFactory {
 
     private static List<CertificateDTO> createCertificateListDTO(UUID freelancerId) {
         return Arrays.asList(
-                new CertificateDTO(1L, "AWS Certified Developer", "AWS", Date.valueOf("2021-05-10"),
+                new CertificateDTO("AWS Certified Developer", "AWS", Date.valueOf("2021-05-10"),
                         Date.valueOf("2024-05-10"), "https://aws.com/cert/12345", freelancerId)
         );
     }


### PR DESCRIPTION
## [Jira@JMK_96](https://punjabskillsbank.atlassian.net/jira/software/projects/JMK/boards/4?selectedIssue=JMK-96)

Updated the ```POST``` mapping for ```/create_profile``` where in DTO, `services` is added, which will contain a list of `category_id` and will be mapped to the `freelancer_services` table for a particular `freelancer_id`

The JSON format will be like 

```json
{
  "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "title": "string",
  "bio": "string",
  "services": [
    1, 2, 3
  ],
  "hourlyRate": 1073741824,
  "address": "string",
  "city": "string",
  "state": "string",
  "country": "string",
  "postalCode": "639038",
  "phoneNumber": "8157929268",
  "profilePhotoURL": "string",
  "educations": [
    {
      "degree": "string",
      "specialization": "string",
      "institution": "string",
      "startYear": 1073741824,
      "endYear": 1073741824,
      "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
    }
  ],
  "jobs": [
    {
      "jobTitle": "string",
      "companyName": "string",
      "startDate": "2025-05-25T07:59:43.568Z",
      "endDate": "2025-05-25T07:59:43.569Z",
      "jobResponsibilities": "string",
      "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
    }
  ],
  "certificates": [
    {
      "certificateName": "string",
      "issuedBy": "string",
      "issueDate": "2025-05-25T07:59:43.569Z",
      "expiryDate": "2025-05-25T07:59:43.569Z",
      "credentialUrl": "string",
      "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
    }
  ],
  "profileStatus": "APPROVED",
  "isAbcMember": true
}
```

### More about this mapping
- No more than 10 services can be added for a particular freelancer, or it will give `ServiceLimitExceededException`
- The POST method itself works as PUT. The explanation is given in line 20 of [FreelancerServicesRepository](https://github.com/punjabskillsbank/jm-profile-management/pull/42/files#diff-db24d3360c64a79c4d2a8d8d32cf9181d2126a83c31ec822d5960150b19c3b21). However, I realised that there is a loophole where whenever this POST method is called, **it will take the whole above-given JSON content**, which is not good. As in the PUT method, we can just use it for services; there is no need for the whole JSON content given above. So yes, it can be removed easily if asked.
- Every time the data is entered for a particular `freelancer_id`, it will be sent to the database in a sorted way w. r. t. `category_id`