### PR TITLE
JMK_103: Add PUT mapping to update categories for specific freelancerId

### DIFF
--- a/src/main/java/com/jobmatrix/controller/FreelancerProfileController.java
+++ b/src/main/java/com/jobmatrix/controller/FreelancerProfileController.java
@@ -2,7 +2,7 @@ package com.jobmatrix.controller;
 
 import com.common.dto.FreelancerDTO;
 import com.common.dto.ProfileVisibilityDTO;
-import com.common.entity.Freelancer;
+import com.common.dto.FreelancerServicesUpdateRequestDTO;
 import com.jobmatrix.service.FreelancerProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,5 +46,14 @@ public class FreelancerProfileController {
     public ResponseEntity<Void> updateProfileVisibility(@Valid @RequestBody ProfileVisibilityDTO dto ) {
         freelancerProfileService.updateProfileVisibility(dto);
         return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{freelancerId}/category")
+    public ResponseEntity<FreelancerDTO> updateCategoriesForFreelancerId(
+            @PathVariable UUID freelancerId,
+            @Valid @RequestBody FreelancerServicesUpdateRequestDTO request) {
+
+        FreelancerDTO updatedFreelancer = freelancerProfileService.updateCategories(freelancerId, request.getCategoryIds());
+        return ResponseEntity.ok(updatedFreelancer);
     }
 }

--- a/src/main/java/com/jobmatrix/service/FreelancerProfileService.java
+++ b/src/main/java/com/jobmatrix/service/FreelancerProfileService.java
@@ -4,9 +4,12 @@ import com.common.dto.FreelancerDTO;
 import com.common.dto.ProfileVisibilityDTO;
 import com.common.entity.Freelancer;
 
+import java.util.Set;
 import java.util.UUID;
 public interface FreelancerProfileService {
     FreelancerDTO createFreelancerProfile(FreelancerDTO freelancerDTO);
     FreelancerDTO getFreelancerProfileById(UUID freelancerId);
     void updateProfileVisibility(ProfileVisibilityDTO dto);
+    FreelancerDTO updateCategories(UUID freelancerId, Set<Long> categoryIds);
+
 }

--- a/src/main/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImpl.java
@@ -71,7 +71,6 @@ public class FreelancerProfileServiceImpl implements FreelancerProfileService {
 
 
     @Override
-
     public FreelancerDTO getFreelancerProfileById(UUID freelancerId) {
         Freelancer freelancer = freelancerRepository.findById(freelancerId)
                 .orElseThrow(() -> new FreelancerNotFoundException(freelancerId));
@@ -83,8 +82,31 @@ public class FreelancerProfileServiceImpl implements FreelancerProfileService {
     public void updateProfileVisibility(ProfileVisibilityDTO dto) {
         Freelancer freelancer = freelancerRepository.findById(dto.getFreelancerId())
                 .orElseThrow(() -> new FreelancerNotFoundException(dto.getFreelancerId()));
-
         freelancer.setProfileVisibility(dto.getProfileVisibility());
         freelancerRepository.save(freelancer);
+    }
+
+    public FreelancerDTO updateCategories(UUID freelancerId, Set<Long> categoryIds) {
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            throw new NullCategoriesOfferedException();
+        } else if (categoryIds.size() > 10) {
+            throw new CategoriesOfferedLimitExceededException();
+        }
+
+        Freelancer freelancer = freelancerRepository.findById(freelancerId)
+                .orElseThrow(() -> new FreelancerNotFoundException(freelancerId));
+
+        Set<Category> newCategories = categoryIds.stream()
+                .map(categoryId -> categoryRepository.findById(categoryId)
+                        .orElseThrow(() -> new CategoryNotFound(categoryId)))
+                .collect(Collectors.toSet());
+
+        freelancer.setCategories(newCategories);  // overwrite existing categories
+
+        Freelancer updatedFreelancer = freelancerRepository.save(freelancer);
+
+        logger.info("Updated categories for freelancer ID: " + freelancerId);
+
+        return mapFreelancerToDTO(updatedFreelancer);
     }
 }

--- a/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.UUID;

--- a/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
@@ -1,9 +1,7 @@
 package com.jobmatrix.controller;
 
 import com.common.dto.FreelancerDTO;
-import com.common.dto.ProfileVisibilityDTO;
 import com.common.entity.Freelancer;
-import com.common.enums.ProfileVisibility;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import com.jobmatrix.service.FreelancerProfileService;
@@ -83,9 +81,7 @@ class FreelancerProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.profileStatus").value("APPROVED"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.educations").isArray())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.jobs").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.certificates").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.profileVisibility").value("PUBLIC"));
-
+                .andExpect(MockMvcResultMatchers.jsonPath("$.certificates").isArray());
     }
 
     private final UUID TEST_ID = UUID.randomUUID();
@@ -118,20 +114,4 @@ class FreelancerProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.isAbcMember").value(true))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.profilePhotoURL").value("https://example.com/profile.jpg"));
     }
-
-    @Test
-    void updateProfileVisibilityTest_shouldReturn204() throws Exception {
-        ProfileVisibilityDTO dto = new ProfileVisibilityDTO();
-        dto.setFreelancerId(FREELANCER_ID);
-        dto.setProfileVisibility(ProfileVisibility.PUBLIC);
-
-        // Mock service method
-        Mockito.doNothing().when(freelancerProfileService).updateProfileVisibility(Mockito.any(ProfileVisibilityDTO.class));
-
-        mockMvc.perform(MockMvcRequestBuilders.patch("/api/freelancer/update_visibility")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(MockMvcResultMatchers.status().isNoContent());
-    }
-
 }

--- a/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
@@ -1,8 +1,12 @@
 package com.jobmatrix.controller;
 
+import com.common.dto.CategoryDTO;
 import com.common.dto.FreelancerDTO;
+import com.common.dto.FreelancerServicesUpdateRequestDTO;
 import com.common.entity.Freelancer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import com.jobmatrix.service.FreelancerProfileService;
 import com.jobmatrix.test_utils.factory.FreelancerTestDataFactory;
@@ -16,7 +20,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.mockito.Mockito.when;
@@ -113,5 +122,35 @@ class FreelancerProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.phoneNumber").value("+919876543210"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.isAbcMember").value(true))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.profilePhotoURL").value("https://example.com/profile.jpg"));
+    }
+
+    @Test
+    void updateCategoriesForFreelancerIdTest() throws Exception {
+        // Create test data
+        Set<Long> categoryIds = new HashSet<>(Arrays.asList(3L, 4L));
+        FreelancerServicesUpdateRequestDTO request = new FreelancerServicesUpdateRequestDTO(categoryIds);
+
+        // Create expected response using the existing mappedResponseDTO
+        Set<CategoryDTO> updatedCategories = new HashSet<>(Arrays.asList(
+                CategoryDTO.builder().categoryId(3L).category("Frontend Development").build(),
+                CategoryDTO.builder().categoryId(4L).category("ReactJS").build()
+        ));
+        FreelancerDTO expectedResponse = mappedResponseDTO.toBuilder()
+                .categoriesDTO(updatedCategories)
+                .build();
+
+        // Mock service behavior
+        when(freelancerProfileService.updateCategories(freelancerId, categoryIds))
+                .thenReturn(expectedResponse);
+
+        // Perform request
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/freelancer/" + freelancerId + "/category")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.categoriesDTO[*].categoryId")
+                        .value(containsInAnyOrder(3, 4)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.categoriesDTO[*].category")
+                        .value(containsInAnyOrder("Frontend Development", "ReactJS")));
     }
 }

--- a/src/test/java/com/jobmatrix/dto/FreelancerServicesUpdateRequestDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/FreelancerServicesUpdateRequestDTOTest.java
@@ -12,15 +12,48 @@ public class FreelancerServicesUpdateRequestDTOTest {
 
     @Test
     void testBuilderAndGetters() {
+        // Test with non-empty set
         Set<Long> categoryIds = Set.of(1L, 2L, 3L);
-
+        
         FreelancerServicesUpdateRequestDTO dto = FreelancerServicesUpdateRequestDTO.builder()
                 .categoryIds(categoryIds)
                 .build();
 
         assertNotNull(dto);
+        assertNotNull(dto.getCategoryIds());
         assertEquals(3, dto.getCategoryIds().size());
+        assertTrue(dto.getCategoryIds().containsAll(categoryIds));
         assertTrue(dto.getCategoryIds().contains(1L));
+        assertTrue(dto.getCategoryIds().contains(2L));
+        assertTrue(dto.getCategoryIds().contains(3L));
+    }
+
+    @Test
+    void testBuilderWithEmptySet() {
+        Set<Long> emptySet = Set.of();
+        
+        FreelancerServicesUpdateRequestDTO dto = FreelancerServicesUpdateRequestDTO.builder()
+                .categoryIds(emptySet)
+                .build();
+
+        assertNotNull(dto);
+        assertNotNull(dto.getCategoryIds());
+        assertTrue(dto.getCategoryIds().isEmpty());
+    }
+
+    @Test
+    void testBuilderChaining() {
+        Set<Long> categoryIds = Set.of(1L, 2L, 3L);
+        
+        FreelancerServicesUpdateRequestDTO dto = FreelancerServicesUpdateRequestDTO.builder()
+                .categoryIds(categoryIds)
+                .categoryIds(categoryIds)
+                .build();
+
+        assertNotNull(dto);
+        assertNotNull(dto.getCategoryIds());
+        assertEquals(3, dto.getCategoryIds().size());
+        assertTrue(dto.getCategoryIds().containsAll(categoryIds));
     }
 
 }

--- a/src/test/java/com/jobmatrix/dto/FreelancerServicesUpdateRequestDTOTest.java
+++ b/src/test/java/com/jobmatrix/dto/FreelancerServicesUpdateRequestDTOTest.java
@@ -1,0 +1,26 @@
+package com.jobmatrix.dto;
+
+
+import com.common.dto.FreelancerServicesUpdateRequestDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FreelancerServicesUpdateRequestDTOTest {
+
+    @Test
+    void testBuilderAndGetters() {
+        Set<Long> categoryIds = Set.of(1L, 2L, 3L);
+
+        FreelancerServicesUpdateRequestDTO dto = FreelancerServicesUpdateRequestDTO.builder()
+                .categoryIds(categoryIds)
+                .build();
+
+        assertNotNull(dto);
+        assertEquals(3, dto.getCategoryIds().size());
+        assertTrue(dto.getCategoryIds().contains(1L));
+    }
+
+}

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -26,7 +26,10 @@ import com.jobmatrix.exceptionHandling.CategoriesOfferedLimitExceededException;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
+
+import java.util.stream.Collectors;
 
 @ExtendWith(MockitoExtension.class)
 class FreelancerProfileServiceImplTest {
@@ -390,5 +393,133 @@ class FreelancerProfileServiceImplTest {
         assertEquals("Category not found with ID: 2", exception.getMessage());
         verify(freelancerRepository).findById(freelancerId);
         verify(categoryRepository, times(2)).findById(anyLong());
+    }
+
+    @Test
+    void completeFlow_createAndUpdateCategories() {
+        // Arrange
+        // Initial categories: 1, 3, 7
+        Set<CategoryDTO> initialCategoryDTOs = Set.of(
+            CategoryDTO.builder().categoryId(1L).category("Category 1").build(),
+            CategoryDTO.builder().categoryId(3L).category("Category 3").build(),
+            CategoryDTO.builder().categoryId(7L).category("Category 7").build()
+        );
+        
+        // Create initial freelancer DTO with categories
+        FreelancerDTO initialFreelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
+        initialFreelancerDTO.setCategoriesDTO(initialCategoryDTOs);
+        
+        // Mock initial categories
+        Set<Category> initialCategories = new HashSet<>();
+        for (CategoryDTO dto : initialCategoryDTOs) {
+            Category category = new Category();
+            category.setCategoryId(dto.getCategoryId());
+            category.setCategory(dto.getCategory());
+            initialCategories.add(category);
+            when(categoryRepository.findById(dto.getCategoryId())).thenReturn(Optional.of(category));
+        }
+        
+        // Mock initial DTO to entity mapping
+        Freelancer initialEntity = FreelancerTestDataFactory.createFreelancerEntity(FREELANCER_ID);
+        when(modelMapper.map(initialFreelancerDTO, Freelancer.class)).thenReturn(initialEntity);
+        
+        // Mock initial save
+        when(freelancerRepository.save(any(Freelancer.class))).thenReturn(initialEntity);
+        
+        // Mock DTO mapping for initial creation
+        FreelancerDTO createdDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
+        
+        // Set categories in the entity before mapping
+        initialEntity.setCategories(initialCategories);
+        
+        // Mock the complete DTO mapping for creation
+        when(modelMapper.map(initialEntity, FreelancerDTO.class)).thenReturn(createdDTO);
+        
+        // Mock category DTO mapping for creation
+        for (Category category : initialCategories) {
+            CategoryDTO categoryDTO = CategoryDTO.builder()
+                .categoryId(category.getCategoryId())
+                .category(category.getCategory())
+                .build();
+            when(modelMapper.map(category, CategoryDTO.class)).thenReturn(categoryDTO);
+        }
+        
+        // Act - Create freelancer
+        FreelancerDTO actualCreatedDTO = freelancerProfileService.createFreelancerProfile(initialFreelancerDTO);
+        
+        // Assert - Verify creation
+        assertNotNull(actualCreatedDTO);
+        assertEquals(FREELANCER_ID, actualCreatedDTO.getFreelancerId());
+        assertNotNull(actualCreatedDTO.getCategoriesDTO());
+        assertEquals(3, actualCreatedDTO.getCategoriesDTO().size());
+        assertTrue(actualCreatedDTO.getCategoriesDTO().stream()
+            .map(CategoryDTO::getCategoryId)
+            .allMatch(id -> id == 1L || id == 3L || id == 7L));
+        
+        // Arrange - Update categories: 2, 5, 7
+        Set<Long> newCategoryIds = Set.of(2L, 5L, 7L);
+        
+        // Mock new categories
+        Set<Category> newCategories = new HashSet<>();
+        for (Long categoryId : newCategoryIds) {
+            Category category = new Category();
+            category.setCategoryId(categoryId);
+            category.setCategory("Category " + categoryId);
+            newCategories.add(category);
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        }
+        
+        // Mock save operation for update
+        when(freelancerRepository.save(any(Freelancer.class))).thenReturn(initialEntity);
+        
+        // Mock the repository to return the entity when finding by ID
+        when(freelancerRepository.findById(FREELANCER_ID)).thenReturn(Optional.of(initialEntity));
+        
+        // Mock DTO mapping for update
+        FreelancerDTO updatedDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
+        
+        // Mock category DTO mapping for update
+        Set<CategoryDTO> expectedCategoryDTOs = new HashSet<>();
+        for (Category category : newCategories) {
+            CategoryDTO categoryDTO = CategoryDTO.builder()
+                .categoryId(category.getCategoryId())
+                .category(category.getCategory())
+                .build();
+            expectedCategoryDTOs.add(categoryDTO);
+            when(modelMapper.map(category, CategoryDTO.class)).thenReturn(categoryDTO);
+        }
+        
+        // Set categories in the entity before mapping for update
+        initialEntity.setCategories(newCategories);
+        
+        // Mock the complete DTO mapping for update
+        when(modelMapper.map(initialEntity, FreelancerDTO.class)).thenReturn(updatedDTO);
+        
+        // Set the categories on the DTO directly
+        updatedDTO.setCategoriesDTO(expectedCategoryDTOs);
+        
+        // Act - Update categories
+        FreelancerDTO actualUpdatedDTO = freelancerProfileService.updateCategories(FREELANCER_ID, newCategoryIds);
+        
+        // Assert - Verify update
+        assertNotNull(actualUpdatedDTO);
+        assertEquals(FREELANCER_ID, actualUpdatedDTO.getFreelancerId());
+        assertNotNull(actualUpdatedDTO.getCategoriesDTO());
+        assertEquals(3, actualUpdatedDTO.getCategoriesDTO().size());
+        assertTrue(actualUpdatedDTO.getCategoriesDTO().containsAll(expectedCategoryDTOs));
+        
+        // Verify that old categories are not present
+        assertFalse(actualUpdatedDTO.getCategoriesDTO().stream()
+            .map(CategoryDTO::getCategoryId)
+            .anyMatch(id -> id == 1L || id == 3L),
+            "Old categories (1 and 3) should not be present in the result");
+        
+        // Verify interactions
+        verify(freelancerRepository, times(2)).save(any(Freelancer.class));
+        verify(modelMapper, times(2)).map(any(Freelancer.class), eq(FreelancerDTO.class));
+        verify(categoryRepository, times(6)).findById(anyLong());
+        for (Category category : newCategories) {
+            verify(modelMapper).map(category, CategoryDTO.class);
+        }
     }
 }

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -369,7 +369,7 @@ class FreelancerProfileServiceImplTest {
     void updateCategories_shouldThrowCategoryNotFound_whenCategoryNotFound() {
         // Arrange
         UUID freelancerId = FREELANCER_ID;
-        Set<Long> categoryIds = Set.of(1L, 2L, 3L);
+        Set<Long> categoryIds = Set.of(1L, 2L);
         
         Freelancer existingFreelancer = FreelancerTestDataFactory.createFreelancerEntity(freelancerId);
         when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(existingFreelancer));
@@ -379,7 +379,7 @@ class FreelancerProfileServiceImplTest {
         category.setCategoryId(1L);
         when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
         
-        // The other categories won't be found
+        // The other category won't be found
         when(categoryRepository.findById(2L)).thenReturn(Optional.empty());
 
         // Act & Assert
@@ -389,5 +389,6 @@ class FreelancerProfileServiceImplTest {
 
         assertEquals("Category not found with ID: 2", exception.getMessage());
         verify(freelancerRepository).findById(freelancerId);
+        verify(categoryRepository, times(2)).findById(anyLong());
     }
 }

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -48,7 +48,6 @@ class FreelancerProfileServiceImplTest {
     private final UUID FREELANCER_ID = UUID.randomUUID();
     private FreelancerDTO inputFreelancerDTO;
     private Freelancer freelancerEntity;
-    private FreelancerDTO freelancerDTO; // This seems unused, can be removed or clarified if needed later
 
     @BeforeEach
     void setup() {
@@ -62,7 +61,7 @@ class FreelancerProfileServiceImplTest {
         // inputFreelancerDTO and freelancerEntity are initialized with categories via FreelancerTestDataFactory
 
         // 1. Mock initial DTO to Entity mapping for Freelancer's main fields
-        when(modelMapper.map(inputFreelancerDTO, Freelancer.class)).thenReturn(freelancerEntity);
+        doReturn(freelancerEntity).when(modelMapper).map(inputFreelancerDTO, Freelancer.class);
 
         // 2. Mock CategoryRepository to return category entities when searched by ID
         // These are the Category entities associated with freelancerEntity from the factory
@@ -99,7 +98,7 @@ class FreelancerProfileServiceImplTest {
                 .profileStatus(freelancerEntity.getProfileStatus())
                 // CategoriesDTO is NOT set here, as the service does it in a subsequent step
                 .build();
-        when(modelMapper.map(any(Freelancer.class), eq(FreelancerDTO.class))).thenReturn(baseMappedResponseDTO);
+        doReturn(baseMappedResponseDTO).when(modelMapper).map(any(Freelancer.class), eq(FreelancerDTO.class));
 
         // 5. Mock mapping of individual Category entities (from saved Freelancer) to CategoryDTOs
         // These are the CategoryDTOs associated with inputFreelancerDTO from the factory
@@ -109,7 +108,7 @@ class FreelancerProfileServiceImplTest {
                 .filter(e -> e.getCategoryId().equals(catDTO.getCategoryId()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Mismatch between test DTO and Entity categories for mocking"));
-            when(modelMapper.map(correspondingEntity, CategoryDTO.class)).thenReturn(catDTO);
+            doReturn(catDTO).when(modelMapper).map(correspondingEntity, CategoryDTO.class);
         }
 
         // Act
@@ -147,7 +146,7 @@ class FreelancerProfileServiceImplTest {
         Freelancer freelancer = new Freelancer();
         FreelancerDTO expectedDTO = FreelancerTestDataFactory.createFreelancerDTO(freelancerId);
         when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(freelancer));
-        when(modelMapper.map(freelancer, FreelancerDTO.class)).thenReturn(expectedDTO);
+        doReturn(expectedDTO).when(modelMapper).map(freelancer, FreelancerDTO.class);
         FreelancerDTO result = freelancerProfileService.getFreelancerProfileById(freelancerId);
         assertNotNull(result);
         assertEquals(expectedDTO, result);
@@ -278,121 +277,61 @@ class FreelancerProfileServiceImplTest {
     @Test
     void updateCategories_success_shouldUpdateCategories() {
         // Arrange
-        UUID freelancerId = FREELANCER_ID;
-        Set<Long> categoryIds = Set.of(1L, 2L);
-        
-        // Mock existing freelancer
-        Freelancer existingFreelancer = FreelancerTestDataFactory.createFreelancerEntity(freelancerId);
-        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(existingFreelancer));
+        // Use existing freelancer from setup()
+        when(freelancerRepository.findById(FREELANCER_ID)).thenReturn(Optional.of(freelancerEntity));
         
         // Mock categories
-        Set<Category> newCategories = new HashSet<>();
+        Set<Category> categories = new HashSet<>();
+        Set<Long> categoryIds = Set.of(1L, 2L); // Define categoryIds here
         for (Long categoryId : categoryIds) {
             Category category = new Category();
             category.setCategoryId(categoryId);
-            newCategories.add(category);
+            categories.add(category);
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
         }
-        
         // Mock save operation
-        when(freelancerRepository.save(any(Freelancer.class))).thenReturn(existingFreelancer);
+        when(freelancerRepository.save(any(Freelancer.class))).thenReturn(freelancerEntity);
         
         // Mock DTO mapping
-        FreelancerDTO expectedDTO = FreelancerTestDataFactory.createFreelancerDTO(freelancerId);
+        FreelancerDTO expectedDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
         
         // Mock category DTO mapping
-        Set<CategoryDTO> expectedCategoryDTOs = new HashSet<>();
-        for (Category category : newCategories) {
+        Set<CategoryDTO> categoryDTOs = new HashSet<>();
+        for (Category category : categories) {
             CategoryDTO categoryDTO = CategoryDTO.builder()
                 .categoryId(category.getCategoryId())
                 .category("Category " + category.getCategoryId())
                 .build();
-            expectedCategoryDTOs.add(categoryDTO);
-            when(modelMapper.map(category, CategoryDTO.class)).thenReturn(categoryDTO);
+            categoryDTOs.add(categoryDTO);
+            doReturn(categoryDTO).when(modelMapper).map(eq(category), eq(CategoryDTO.class));
         }
         
+        // Set categories in the expected DTO
+        expectedDTO.setCategoriesDTO(categoryDTOs);
+        
         // Mock final DTO mapping
-        when(modelMapper.map(existingFreelancer, FreelancerDTO.class)).thenReturn(expectedDTO);
+        doReturn(expectedDTO).when(modelMapper).map(freelancerEntity, FreelancerDTO.class);
 
         // Act
-        FreelancerDTO result = freelancerProfileService.updateCategories(freelancerId, categoryIds);
+        FreelancerDTO result = freelancerProfileService.updateCategories(FREELANCER_ID, categoryIds);
 
         // Assert
         assertNotNull(result);
-        assertEquals(freelancerId, result.getFreelancerId());
+        assertEquals(FREELANCER_ID, result.getFreelancerId());
         assertNotNull(result.getCategoriesDTO());
-        assertEquals(newCategories.size(), result.getCategoriesDTO().size());
-        assertTrue(result.getCategoriesDTO().containsAll(expectedCategoryDTOs));
+        assertEquals(categories.size(), result.getCategoriesDTO().size());
+        assertTrue(result.getCategoriesDTO().containsAll(categoryDTOs));
         
         // Verify interactions
-        verify(freelancerRepository).findById(freelancerId);
+        verify(freelancerRepository).findById(FREELANCER_ID);
         for (Long categoryId : categoryIds) {
             verify(categoryRepository).findById(categoryId);
         }
         verify(freelancerRepository).save(any(Freelancer.class));
-        verify(modelMapper).map(existingFreelancer, FreelancerDTO.class);
-        for (Category category : newCategories) {
-            verify(modelMapper).map(category, CategoryDTO.class);
+        verify(modelMapper).map(freelancerEntity, FreelancerDTO.class);
+        for (Category category : categories) {
+            verify(modelMapper).map(eq(category), eq(CategoryDTO.class));
         }
-    }
-
-    @Test
-    void updateCategories_shouldThrowFreelancerNotFoundException_whenFreelancerNotFound() {
-        // Arrange
-        UUID freelancerId = FREELANCER_ID;
-        Set<Long> categoryIds = Set.of(1L, 2L);
-        
-        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.empty());
-
-        // Act & Assert
-        FreelancerNotFoundException exception = assertThrows(FreelancerNotFoundException.class, () -> {
-            freelancerProfileService.updateCategories(freelancerId, categoryIds);
-        });
-
-        assertEquals("Freelancer not found with ID: " + freelancerId, exception.getMessage());
-        verify(freelancerRepository).findById(freelancerId);
-        verifyNoInteractions(categoryRepository);
-    }
-
-    @Test
-    void updateCategories_shouldThrowCategoriesOfferedLimitExceededException_whenTooManyCategories() {
-        // Arrange
-        UUID freelancerId = FREELANCER_ID;
-        Set<Long> tooManyCategoryIds = Set.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
-
-        // Act & Assert
-        CategoriesOfferedLimitExceededException exception = assertThrows(CategoriesOfferedLimitExceededException.class, () -> {
-            freelancerProfileService.updateCategories(freelancerId, tooManyCategoryIds);
-        });
-
-        assertEquals("Cannot assign more than 10 categories.", exception.getMessage());
-    }
-
-    @Test
-    void updateCategories_shouldThrowCategoryNotFound_whenCategoryNotFound() {
-        // Arrange
-        UUID freelancerId = FREELANCER_ID;
-        Set<Long> categoryIds = Set.of(1L, 2L);
-        
-        Freelancer existingFreelancer = FreelancerTestDataFactory.createFreelancerEntity(freelancerId);
-        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(existingFreelancer));
-        
-        // Only mock one category to be found
-        Category category = new Category();
-        category.setCategoryId(1L);
-        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
-        
-        // The other category won't be found
-        when(categoryRepository.findById(2L)).thenReturn(Optional.empty());
-
-        // Act & Assert
-        CategoryNotFound exception = assertThrows(CategoryNotFound.class, () -> {
-            freelancerProfileService.updateCategories(freelancerId, categoryIds);
-        });
-
-        assertEquals("Category not found with ID: 2", exception.getMessage());
-        verify(freelancerRepository).findById(freelancerId);
-        verify(categoryRepository, times(2)).findById(anyLong());
     }
 
     @Test
@@ -400,15 +339,15 @@ class FreelancerProfileServiceImplTest {
         // Arrange
         // Initial categories: 1, 3, 7
         Set<CategoryDTO> initialCategoryDTOs = Set.of(
-            CategoryDTO.builder().categoryId(1L).category("Category 1").build(),
-            CategoryDTO.builder().categoryId(3L).category("Category 3").build(),
-            CategoryDTO.builder().categoryId(7L).category("Category 7").build()
+                CategoryDTO.builder().categoryId(1L).category("Category 1").build(),
+                CategoryDTO.builder().categoryId(3L).category("Category 3").build(),
+                CategoryDTO.builder().categoryId(7L).category("Category 7").build()
         );
-        
+
         // Create initial freelancer DTO with categories
         FreelancerDTO initialFreelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
         initialFreelancerDTO.setCategoriesDTO(initialCategoryDTOs);
-        
+
         // Mock initial categories
         Set<Category> initialCategories = new HashSet<>();
         for (CategoryDTO dto : initialCategoryDTOs) {
@@ -418,47 +357,47 @@ class FreelancerProfileServiceImplTest {
             initialCategories.add(category);
             when(categoryRepository.findById(dto.getCategoryId())).thenReturn(Optional.of(category));
         }
-        
+
         // Mock initial DTO to entity mapping
         Freelancer initialEntity = FreelancerTestDataFactory.createFreelancerEntity(FREELANCER_ID);
         when(modelMapper.map(initialFreelancerDTO, Freelancer.class)).thenReturn(initialEntity);
-        
+
         // Mock initial save
         when(freelancerRepository.save(any(Freelancer.class))).thenReturn(initialEntity);
-        
+
         // Mock DTO mapping for initial creation
         FreelancerDTO createdDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
-        
+
         // Set categories in the entity before mapping
         initialEntity.setCategories(initialCategories);
-        
+
         // Mock the complete DTO mapping for creation
         when(modelMapper.map(initialEntity, FreelancerDTO.class)).thenReturn(createdDTO);
-        
+
         // Mock category DTO mapping for creation
         for (Category category : initialCategories) {
             CategoryDTO categoryDTO = CategoryDTO.builder()
-                .categoryId(category.getCategoryId())
-                .category(category.getCategory())
-                .build();
+                    .categoryId(category.getCategoryId())
+                    .category(category.getCategory())
+                    .build();
             when(modelMapper.map(category, CategoryDTO.class)).thenReturn(categoryDTO);
         }
-        
+
         // Act - Create freelancer
         FreelancerDTO actualCreatedDTO = freelancerProfileService.createFreelancerProfile(initialFreelancerDTO);
-        
+
         // Assert - Verify creation
         assertNotNull(actualCreatedDTO);
         assertEquals(FREELANCER_ID, actualCreatedDTO.getFreelancerId());
         assertNotNull(actualCreatedDTO.getCategoriesDTO());
         assertEquals(3, actualCreatedDTO.getCategoriesDTO().size());
         assertTrue(actualCreatedDTO.getCategoriesDTO().stream()
-            .map(CategoryDTO::getCategoryId)
-            .allMatch(id -> id == 1L || id == 3L || id == 7L));
-        
+                .map(CategoryDTO::getCategoryId)
+                .allMatch(id -> id == 1L || id == 3L || id == 7L));
+
         // Arrange - Update categories: 2, 5, 7
         Set<Long> newCategoryIds = Set.of(2L, 5L, 7L);
-        
+
         // Mock new categories
         Set<Category> newCategories = new HashSet<>();
         for (Long categoryId : newCategoryIds) {
@@ -468,52 +407,52 @@ class FreelancerProfileServiceImplTest {
             newCategories.add(category);
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
         }
-        
+
         // Mock save operation for update
         when(freelancerRepository.save(any(Freelancer.class))).thenReturn(initialEntity);
-        
+
         // Mock the repository to return the entity when finding by ID
         when(freelancerRepository.findById(FREELANCER_ID)).thenReturn(Optional.of(initialEntity));
-        
+
         // Mock DTO mapping for update
         FreelancerDTO updatedDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
-        
+
         // Mock category DTO mapping for update
         Set<CategoryDTO> expectedCategoryDTOs = new HashSet<>();
         for (Category category : newCategories) {
             CategoryDTO categoryDTO = CategoryDTO.builder()
-                .categoryId(category.getCategoryId())
-                .category(category.getCategory())
-                .build();
+                    .categoryId(category.getCategoryId())
+                    .category(category.getCategory())
+                    .build();
             expectedCategoryDTOs.add(categoryDTO);
             when(modelMapper.map(category, CategoryDTO.class)).thenReturn(categoryDTO);
         }
-        
+
         // Set categories in the entity before mapping for update
         initialEntity.setCategories(newCategories);
-        
+
         // Mock the complete DTO mapping for update
         when(modelMapper.map(initialEntity, FreelancerDTO.class)).thenReturn(updatedDTO);
-        
+
         // Set the categories on the DTO directly
         updatedDTO.setCategoriesDTO(expectedCategoryDTOs);
-        
+
         // Act - Update categories
         FreelancerDTO actualUpdatedDTO = freelancerProfileService.updateCategories(FREELANCER_ID, newCategoryIds);
-        
+
         // Assert - Verify update
         assertNotNull(actualUpdatedDTO);
         assertEquals(FREELANCER_ID, actualUpdatedDTO.getFreelancerId());
         assertNotNull(actualUpdatedDTO.getCategoriesDTO());
         assertEquals(3, actualUpdatedDTO.getCategoriesDTO().size());
         assertTrue(actualUpdatedDTO.getCategoriesDTO().containsAll(expectedCategoryDTOs));
-        
+
         // Verify that old categories are not present
         assertFalse(actualUpdatedDTO.getCategoriesDTO().stream()
-            .map(CategoryDTO::getCategoryId)
-            .anyMatch(id -> id == 1L || id == 3L),
-            "Old categories (1 and 3) should not be present in the result");
-        
+                        .map(CategoryDTO::getCategoryId)
+                        .anyMatch(id -> id == 1L || id == 3L),
+                "Old categories (1 and 3) should not be present in the result");
+
         // Verify interactions
         verify(freelancerRepository, times(2)).save(any(Freelancer.class));
         verify(modelMapper, times(2)).map(any(Freelancer.class), eq(FreelancerDTO.class));

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -14,16 +14,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-import java.util.Optional;
-import java.util.UUID;
+
+import java.util.*;
+
 import com.common.dto.CategoryDTO;
 import com.common.entity.Category;
 import com.jobmatrix.exceptionHandling.CategoryNotFound;
 import com.jobmatrix.exceptionHandling.NullCategoriesOfferedException;
 import com.jobmatrix.exceptionHandling.CategoriesOfferedLimitExceededException;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Collections;
+
 import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,12 +33,14 @@ class FreelancerProfileServiceImplTest {
 
     @Mock
     private FreelancerRepository freelancerRepository;
+
     @Mock
     private ModelMapper modelMapper;
+
     @Mock
     private CategoryRepository categoryRepository;
-    @InjectMocks
 
+    @InjectMocks
     private FreelancerProfileServiceImpl freelancerProfileService;
     private final UUID FREELANCER_ID = UUID.randomUUID();
     private FreelancerDTO inputFreelancerDTO;
@@ -270,5 +271,123 @@ class FreelancerProfileServiceImplTest {
         verify(freelancerRepository).findById(FREELANCER_ID);
         verify(freelancerRepository, never()).save(any());
     }
-}
 
+    @Test
+    void updateCategories_success_shouldUpdateCategories() {
+        // Arrange
+        UUID freelancerId = FREELANCER_ID;
+        Set<Long> categoryIds = Set.of(1L, 2L);
+        
+        // Mock existing freelancer
+        Freelancer existingFreelancer = FreelancerTestDataFactory.createFreelancerEntity(freelancerId);
+        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(existingFreelancer));
+        
+        // Mock categories
+        Set<Category> newCategories = new HashSet<>();
+        for (Long categoryId : categoryIds) {
+            Category category = new Category();
+            category.setCategoryId(categoryId);
+            newCategories.add(category);
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+        }
+        
+        // Mock save operation
+        when(freelancerRepository.save(any(Freelancer.class))).thenReturn(existingFreelancer);
+        
+        // Mock DTO mapping
+        FreelancerDTO expectedDTO = FreelancerTestDataFactory.createFreelancerDTO(freelancerId);
+        
+        // Mock category DTO mapping
+        Set<CategoryDTO> expectedCategoryDTOs = new HashSet<>();
+        for (Category category : newCategories) {
+            CategoryDTO categoryDTO = CategoryDTO.builder()
+                .categoryId(category.getCategoryId())
+                .category("Category " + category.getCategoryId())
+                .build();
+            expectedCategoryDTOs.add(categoryDTO);
+            when(modelMapper.map(category, CategoryDTO.class)).thenReturn(categoryDTO);
+        }
+        
+        // Mock final DTO mapping
+        when(modelMapper.map(existingFreelancer, FreelancerDTO.class)).thenReturn(expectedDTO);
+
+        // Act
+        FreelancerDTO result = freelancerProfileService.updateCategories(freelancerId, categoryIds);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(freelancerId, result.getFreelancerId());
+        assertNotNull(result.getCategoriesDTO());
+        assertEquals(newCategories.size(), result.getCategoriesDTO().size());
+        assertTrue(result.getCategoriesDTO().containsAll(expectedCategoryDTOs));
+        
+        // Verify interactions
+        verify(freelancerRepository).findById(freelancerId);
+        for (Long categoryId : categoryIds) {
+            verify(categoryRepository).findById(categoryId);
+        }
+        verify(freelancerRepository).save(any(Freelancer.class));
+        verify(modelMapper).map(existingFreelancer, FreelancerDTO.class);
+        for (Category category : newCategories) {
+            verify(modelMapper).map(category, CategoryDTO.class);
+        }
+    }
+
+    @Test
+    void updateCategories_shouldThrowFreelancerNotFoundException_whenFreelancerNotFound() {
+        // Arrange
+        UUID freelancerId = FREELANCER_ID;
+        Set<Long> categoryIds = Set.of(1L, 2L);
+        
+        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        FreelancerNotFoundException exception = assertThrows(FreelancerNotFoundException.class, () -> {
+            freelancerProfileService.updateCategories(freelancerId, categoryIds);
+        });
+
+        assertEquals("Freelancer not found with ID: " + freelancerId, exception.getMessage());
+        verify(freelancerRepository).findById(freelancerId);
+        verifyNoInteractions(categoryRepository);
+    }
+
+    @Test
+    void updateCategories_shouldThrowCategoriesOfferedLimitExceededException_whenTooManyCategories() {
+        // Arrange
+        UUID freelancerId = FREELANCER_ID;
+        Set<Long> tooManyCategoryIds = Set.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+
+        // Act & Assert
+        CategoriesOfferedLimitExceededException exception = assertThrows(CategoriesOfferedLimitExceededException.class, () -> {
+            freelancerProfileService.updateCategories(freelancerId, tooManyCategoryIds);
+        });
+
+        assertEquals("Cannot assign more than 10 categories.", exception.getMessage());
+    }
+
+    @Test
+    void updateCategories_shouldThrowCategoryNotFound_whenCategoryNotFound() {
+        // Arrange
+        UUID freelancerId = FREELANCER_ID;
+        Set<Long> categoryIds = Set.of(1L, 2L, 3L);
+        
+        Freelancer existingFreelancer = FreelancerTestDataFactory.createFreelancerEntity(freelancerId);
+        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(existingFreelancer));
+        
+        // Only mock one category to be found
+        Category category = new Category();
+        category.setCategoryId(1L);
+        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        
+        // The other categories won't be found
+        when(categoryRepository.findById(2L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        CategoryNotFound exception = assertThrows(CategoryNotFound.class, () -> {
+            freelancerProfileService.updateCategories(freelancerId, categoryIds);
+        });
+
+        assertEquals("Category not found with ID: 2", exception.getMessage());
+        verify(freelancerRepository).findById(freelancerId);
+    }
+}


### PR DESCRIPTION
## [Jira@JMK_103](https://punjabskillsbank.atlassian.net/browse/JMK-103?atlOrigin=eyJpIjoiZmY0YTFhYjIwZTRmNGNkMjhiZDYwODEyMDM4YWMxZGQiLCJwIjoiaiJ9)

Added a PUT mapping for `/api/freelancer/{freelancerId}/category` which will contain a set of Categories and will be mapped to the `freelancer_services` table for a particular `freelancer_id` by overwriting existing data for a specific `freelancer_id`

The JSON format will be like
```json
{
  "categoryIds": [
1, 2, 3, 4
  ]
}
```

And in the response body, it shows

```json
{
  "freelancerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "title": "string",
  "bio": "string",
  "categoriesDTO": [
    {
      "categoryId": 3,
      "category": "Accounting & Consulting",
      "speciality": "Financial Planning"
    },
    {
      "categoryId": 1,
      "category": "Accounting & Consulting",
      "speciality": "Personal & Professional Coaching"
    },
    {
      "categoryId": 2,
      "category": "Accounting & Consulting",
      "speciality": "Accounting & Bookkeeping"
    },
    {
      "categoryId": 4,
      "category": "Accounting & Consulting",
      "speciality": "Recruiting & Human Resources"
    }
  ],
  "hourlyRate": 1073741824,
  "address": "string",
  "city": "string",
  "state": "string",
  "country": "string",
  "postalCode": "826489",
  "phoneNumber": "7809852257",
  "profilePhotoURL": "string",
  "educations": [],
  "jobs": [],
  "certificates": [],
  "profileStatus": "APPROVED",
  "isAbcMember": true
}
```

