### PR TITLE
JMK_85: support for Freelancer Profile Creation with profile photo upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
 			<version>1.2.17</version>
 		</dependency>
 		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>2.31.40</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.6</version>

--- a/src/main/java/com/jobmatrix/JmProfileManagementApplication.java
+++ b/src/main/java/com/jobmatrix/JmProfileManagementApplication.java
@@ -1,5 +1,6 @@
 package com.jobmatrix;
 
+import com.common.config.AwsConfig;
 import com.common.config.CorsConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,7 +8,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import(CorsConfig.class)
+@Import({CorsConfig.class, AwsConfig.class})
 @EntityScan(basePackages = {"com.jobmatrix", "com.common.entity"})
 public class JmProfileManagementApplication {
 

--- a/src/main/java/com/jobmatrix/config/S3Config.java
+++ b/src/main/java/com/jobmatrix/config/S3Config.java
@@ -1,0 +1,23 @@
+package com.jobmatrix.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/jobmatrix/controller/FreelancerProfileController.java
+++ b/src/main/java/com/jobmatrix/controller/FreelancerProfileController.java
@@ -24,7 +24,7 @@ public class FreelancerProfileController {
     private final ModelMapper modelMapper;
 
     @PostMapping("/create_profile")
-    public ResponseEntity<FreelancerDTO> initiateProfileCreation(
+    public ResponseEntity<FreelancerDTO> createFreelancerProfile(
             @Valid @RequestBody FreelancerDTO freelancerDTO
     ) {
         FreelancerDTO result = freelancerProfileService.createFreelancerProfile(freelancerDTO);

--- a/src/main/java/com/jobmatrix/controller/FreelancerProfileController.java
+++ b/src/main/java/com/jobmatrix/controller/FreelancerProfileController.java
@@ -10,10 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.UUID;
 
 @RestController
@@ -25,12 +23,12 @@ public class FreelancerProfileController {
     private final FreelancerProfileService freelancerProfileService;
     private final ModelMapper modelMapper;
 
-    // POST mapping to save the freelancer profile data in database
-    @Operation(summary = "Create a new freelancer profile", description = "Save the freelancer profile data in the database")
     @PostMapping("/create_profile")
-    public ResponseEntity<FreelancerDTO> createProfile(@Valid @RequestBody FreelancerDTO freelancerDTO) {
-        FreelancerDTO dto  = freelancerProfileService.createFreelancerProfile(freelancerDTO);
-        return new ResponseEntity<>(dto, HttpStatus.CREATED);
+    public ResponseEntity<FreelancerDTO> initiateProfileCreation(
+            @Valid @RequestBody FreelancerDTO freelancerDTO
+    ) {
+        FreelancerDTO result = freelancerProfileService.createFreelancerProfile(freelancerDTO);
+        return ResponseEntity.ok(result);
     }
 
     //GET mapping for the freelancer

--- a/src/main/java/com/jobmatrix/controller/PresignedUrlController.java
+++ b/src/main/java/com/jobmatrix/controller/PresignedUrlController.java
@@ -1,0 +1,24 @@
+package com.jobmatrix.controller;
+
+import com.jobmatrix.dto.PresignedUrlResponse;
+import com.jobmatrix.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/presigned_url")
+@RequiredArgsConstructor
+public class PresignedUrlController {
+
+    private final FileService fileService;
+
+    @GetMapping("/upload")
+    public ResponseEntity<PresignedUrlResponse> generateUploadUrl(@RequestParam String userId, @RequestParam String contentType) {
+        PresignedUrlResponse presignedUrlResponse = fileService.generateProfilePhotoUrl(userId, contentType);
+        return ResponseEntity.ok(presignedUrlResponse);
+    }
+}

--- a/src/main/java/com/jobmatrix/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/jobmatrix/dto/PresignedUrlResponse.java
@@ -1,0 +1,15 @@
+package com.jobmatrix.dto;
+
+import lombok.*;
+import java.net.URL;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class PresignedUrlResponse {
+    private URL uploadUrl;
+    private String s3Key;
+
+}

--- a/src/main/java/com/jobmatrix/service/FileService.java
+++ b/src/main/java/com/jobmatrix/service/FileService.java
@@ -1,0 +1,16 @@
+package com.jobmatrix.service;
+
+import com.jobmatrix.dto.PresignedUrlResponse;
+
+public interface FileService {
+
+    /**
+     * Generates presigned URLs for uploading and downloading a profile photo
+     *
+     * @param userId      the ID of the user
+     * @param contentType the MIME type of the file
+     * @return an array containing [uploadUrl, downloadUrl]
+     */
+    PresignedUrlResponse generateProfilePhotoUrl(String userId, String contentType);
+
+}

--- a/src/main/java/com/jobmatrix/service/S3Service.java
+++ b/src/main/java/com/jobmatrix/service/S3Service.java
@@ -1,0 +1,17 @@
+package com.jobmatrix.service;
+
+import java.io.InputStream;
+import java.net.URL;
+
+public interface S3Service {
+
+    /**
+     * Generates a presigned URL for uploading a file to S3
+     *
+     * @param fileName the name to give the file in S3
+     * @param contentType the MIME type of the file
+     * @return the presigned URL for uploading
+     */
+    URL generatePresignedUploadUrl(String fileName, String contentType);
+
+}

--- a/src/main/java/com/jobmatrix/serviceimpl/FileServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/FileServiceImpl.java
@@ -1,0 +1,59 @@
+package com.jobmatrix.serviceimpl;
+
+import com.jobmatrix.dto.PresignedUrlResponse;
+import com.jobmatrix.repository.ClientProfileRepository;
+import com.jobmatrix.service.FileService;
+import com.jobmatrix.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Service;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService {
+
+    private static final Logger logger = Logger.getLogger(FileServiceImpl.class);
+    private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+            "image/jpeg", "image/jpg", "image/png", "image/webp"
+    );
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    private final S3Service s3Service;
+    private final ClientProfileRepository clientProfileRepository;
+
+    @Override
+    public PresignedUrlResponse generateProfilePhotoUrl(String userId, String contentType) {
+        validateContentType(contentType);
+
+        // creates the S3 key for the profile photo
+        String s3Key = "profile_photos/" + userId + getFileExtension(contentType);
+
+        // Generate presigned URL for uploading the profile photo
+        URL uploadUrl = s3Service.generatePresignedUploadUrl(s3Key, contentType);
+
+        return new PresignedUrlResponse(uploadUrl, s3Key);
+    }
+
+    private void validateContentType(String contentType) {
+        if (contentType == null || !ALLOWED_IMAGE_TYPES.contains(contentType.toLowerCase())) {
+            throw new IllegalArgumentException("Only image files (JPEG, JPG, PNG, WEBP) are allowed");
+        }
+    }
+
+    private String getFileExtension(String contentType) {
+        switch (contentType.toLowerCase()) {
+            case "image/jpeg":
+            case "image/jpg":
+                return ".jpg";
+            case "image/png":
+                return ".png";
+            case "image/webp":
+                return ".webp";
+            default:
+                throw new IllegalArgumentException("Unsupported image type: " + contentType);
+        }
+    }
+}

--- a/src/main/java/com/jobmatrix/serviceimpl/S3ServiceImpl.java
+++ b/src/main/java/com/jobmatrix/serviceimpl/S3ServiceImpl.java
@@ -1,0 +1,45 @@
+package com.jobmatrix.serviceimpl;
+
+import com.jobmatrix.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import java.net.URL;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service {
+
+    private static final Logger logger = Logger.getLogger(S3ServiceImpl.class);
+    private static final Duration UPLOAD_URL_EXPIRATION = Duration.ofMinutes(60);
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    private final S3Presigner s3Presigner;
+
+    @Override
+    public URL generatePresignedUploadUrl(String fileName, String contentType) {
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(UPLOAD_URL_EXPIRATION)
+                .putObjectRequest(objectRequest)
+                .build();
+
+        URL presignedUrl = s3Presigner.presignPutObject(presignRequest).url();
+        logger.info("Generated presigned upload URL for file: " + fileName);
+        return presignedUrl;
+
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,18 @@ spring.jpa.show-sql = true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.hikari.maximum-pool-size = 10
 
+#spring.profiles.active=local
+
+# AWS S3 Configuration
+
+aws.region=ap-south-1
+aws.s3.bucket-name=jm-profile-management-demo-bucket
+
+# Multipart file configuration
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
 spring.profiles.active=local
 
 logging.level.org.springframework.web=DEBUG

--- a/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
@@ -5,9 +5,6 @@ import com.common.dto.FreelancerDTO;
 import com.common.dto.FreelancerServicesUpdateRequestDTO;
 import com.common.entity.Freelancer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import com.jobmatrix.service.FreelancerProfileService;
 import com.jobmatrix.test_utils.factory.FreelancerTestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,18 +17,15 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.Mockito.when;
 
 @WebMvcTest(FreelancerProfileController.class)
-
 class FreelancerProfileControllerTest {
 
     @MockitoBean
@@ -58,23 +52,23 @@ class FreelancerProfileControllerTest {
         inputFreelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
         savedFreelancer = FreelancerTestDataFactory.createFreelancerEntity(FREELANCER_ID);
         mappedResponseDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
+        freelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
     }
 
     @Test
-    void createFreelancerProfileTest() throws Exception {
+    void initiateProfileCreationTest() throws Exception {
 
-        // Mock service behavior (assuming create returns the created profile)
-        when(freelancerProfileService.createFreelancerProfile(Mockito.any(FreelancerDTO.class)))
-                .thenReturn(mappedResponseDTO);
+        // Mock service behavior (assuming initiateProfileCreation returns an array with the created profile and upload URL)
+        when(freelancerProfileService.createFreelancerProfile(Mockito.any(FreelancerDTO.class))).thenReturn(freelancerDTO);
 
         when(modelMapper.map(savedFreelancer, FreelancerDTO.class))
-                .thenReturn(mappedResponseDTO);
+                .thenReturn(freelancerDTO);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/freelancer/create_profile")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(inputFreelancerDTO)))
-                .andDo(print())
-                .andExpect(MockMvcResultMatchers.status().isCreated()) // Expect 201 Created
+                        .content(objectMapper.writeValueAsString(freelancerDTO)))
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.freelancerId").value(FREELANCER_ID.toString()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Senior Software Engineer"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.bio").value("Experienced Java and Spring Boot developer"))
@@ -86,31 +80,19 @@ class FreelancerProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.postalCode").value("560001"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.phoneNumber").value("+919876543210"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.isAbcMember").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.profilePhotoURL").value("https://example.com/profile.jpg"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.profileStatus").value("APPROVED"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.educations").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.jobs").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.certificates").isArray());
-    }
-
-    private final UUID TEST_ID = UUID.randomUUID();
-
-    @BeforeEach
-    void setUp() {
-        freelancerId = TEST_ID;
-        freelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(freelancerId);
+                .andExpect(MockMvcResultMatchers.jsonPath("$.profilePhotoS3Key").value("profile_photos/" + FREELANCER_ID + ".jpg"));
     }
 
     @Test
     void getFreelancerByIdTest() throws Exception {
 
-        Mockito.when(freelancerProfileService.getFreelancerProfileById(freelancerId))
+        Mockito.when(freelancerProfileService.getFreelancerProfileById(FREELANCER_ID))
                 .thenReturn(freelancerDTO);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/freelancer/" + freelancerId)
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/freelancer/" + FREELANCER_ID)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.freelancerId").value(freelancerId.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.freelancerId").value(FREELANCER_ID.toString()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Senior Software Engineer"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.bio").value("Experienced Java and Spring Boot developer"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.hourlyRate").value(50.0))
@@ -121,7 +103,7 @@ class FreelancerProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.postalCode").value("560001"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.phoneNumber").value("+919876543210"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.isAbcMember").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.profilePhotoURL").value("https://example.com/profile.jpg"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.profilePhotoS3Key").value("profile_photos/" + FREELANCER_ID + ".jpg"));
     }
 
     @Test
@@ -140,11 +122,11 @@ class FreelancerProfileControllerTest {
                 .build();
 
         // Mock service behavior
-        when(freelancerProfileService.updateCategories(freelancerId, categoryIds))
+        when(freelancerProfileService.updateCategories(FREELANCER_ID, categoryIds))
                 .thenReturn(expectedResponse);
 
         // Perform request
-        mockMvc.perform(MockMvcRequestBuilders.put("/api/freelancer/" + freelancerId + "/category")
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/freelancer/" + FREELANCER_ID + "/category")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/FreelancerProfileControllerTest.java
@@ -56,9 +56,9 @@ class FreelancerProfileControllerTest {
     }
 
     @Test
-    void initiateProfileCreationTest() throws Exception {
+    void FreelancerProfileCreationTest() throws Exception {
 
-        // Mock service behavior (assuming initiateProfileCreation returns an array with the created profile and upload URL)
+        // Mock service behavior (assuming createFreelancerProfile returns an array with the created profile and upload URL)
         when(freelancerProfileService.createFreelancerProfile(Mockito.any(FreelancerDTO.class))).thenReturn(freelancerDTO);
 
         when(modelMapper.map(savedFreelancer, FreelancerDTO.class))

--- a/src/test/java/com/jobmatrix/controller/PresignedUrlControllerTest.java
+++ b/src/test/java/com/jobmatrix/controller/PresignedUrlControllerTest.java
@@ -1,0 +1,59 @@
+package com.jobmatrix.controller;
+
+import com.jobmatrix.dto.PresignedUrlResponse;
+import com.jobmatrix.service.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PresignedUrlController.class)
+public class PresignedUrlControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private FileService fileService;
+
+    private PresignedUrlResponse presignedUrlResponse;
+    private final UUID FREELANCER_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setup() {
+
+        try {
+            URL uploadUrl = new URL("https://s3-upload-url");
+            presignedUrlResponse = new PresignedUrlResponse();
+            presignedUrlResponse.setS3Key("profile-photos/" + FREELANCER_ID + ".jpg");
+            presignedUrlResponse.setUploadUrl(uploadUrl);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed to construct upload URL", e);
+        }
+    }
+
+    @Test
+    public void testGenerateProfilePhotoUrl() throws Exception {
+        // Mock the service call
+        when(fileService.generateProfilePhotoUrl(anyString(), anyString())).thenReturn(presignedUrlResponse);
+
+        // Perform the request and verify the response
+        mockMvc.perform(get("/api/presigned_url/upload")
+                        .param("userId", FREELANCER_ID.toString())
+                        .param("contentType", "image/jpeg"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.s3Key").value(presignedUrlResponse.getS3Key()))
+                .andExpect(jsonPath("$.uploadUrl").value(presignedUrlResponse.getUploadUrl().toString()));
+    }
+
+}

--- a/src/test/java/com/jobmatrix/serviceimpl/FileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FileServiceImplTest.java
@@ -1,0 +1,82 @@
+package com.jobmatrix.serviceimpl;
+
+import com.jobmatrix.dto.PresignedUrlResponse;
+import com.jobmatrix.repository.ClientProfileRepository;
+import com.jobmatrix.service.S3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FileServiceImplTest {
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private ClientProfileRepository clientProfileRepository;
+
+    @InjectMocks
+    private FileServiceImpl fileService;
+
+    private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+            "image/jpeg", "image/jpg", "image/png", "image/webp"
+    );
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;// 10MB
+    private PresignedUrlResponse presignedUrlResponse;
+    private final UUID FREELANCER_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setup() {
+
+        try {
+            URL uploadUrl = new URL("https://s3-upload-url");
+            presignedUrlResponse = new PresignedUrlResponse();
+            presignedUrlResponse.setS3Key("profile_photos/" + FREELANCER_ID + ".jpg");
+            presignedUrlResponse.setUploadUrl(uploadUrl);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed to construct upload URL", e);
+        }
+    }
+
+    @Test
+    void generateProfilePhotoUrl_givenValidInput_returnsPresignedUrl() {
+        String contentType = "image/jpg";
+
+        when(s3Service.generatePresignedUploadUrl(any(String.class), eq(contentType)))
+                .thenReturn(presignedUrlResponse.getUploadUrl());
+
+        // Call the method under test
+        PresignedUrlResponse response = fileService.generateProfilePhotoUrl(FREELANCER_ID.toString(), contentType);
+
+        // Validate the response
+        assertNotNull(response);
+        assertEquals(presignedUrlResponse.getS3Key(), response.getS3Key());
+        assertEquals(presignedUrlResponse.getUploadUrl(), response.getUploadUrl());
+    }
+
+    @Test
+    void generateProfilePhotoUrl_givenInvalidContentType_throwsIllegalArgumentException() {
+        String invalidContentType = "application/pdf";
+
+        try {
+            fileService.generateProfilePhotoUrl(FREELANCER_ID.toString(), invalidContentType);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Only image files (JPEG, JPG, PNG, WEBP) are allowed", e.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/FreelancerProfileServiceImplTest.java
@@ -5,6 +5,7 @@ import com.common.entity.Freelancer;
 import com.common.enums.ProfileVisibility;
 import com.common.exceptionHandling.FreelancerNotFoundException;
 import com.jobmatrix.repository.FreelancerRepository;
+import com.jobmatrix.service.FileService;
 import com.jobmatrix.repository.CategoryRepository;
 import com.jobmatrix.test_utils.factory.FreelancerTestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,21 +15,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-
+import java.net.MalformedURLException;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.*;
-
 import com.common.dto.CategoryDTO;
 import com.common.entity.Category;
 import com.jobmatrix.exceptionHandling.CategoryNotFound;
 import com.jobmatrix.exceptionHandling.NullCategoriesOfferedException;
 import com.jobmatrix.exceptionHandling.CategoriesOfferedLimitExceededException;
-
 import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
-
 import java.util.stream.Collectors;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,16 +41,22 @@ class FreelancerProfileServiceImplTest {
     private ModelMapper modelMapper;
 
     @Mock
+    private FileService fileService;
+
+
+    @Mock
     private CategoryRepository categoryRepository;
 
     @InjectMocks
     private FreelancerProfileServiceImpl freelancerProfileService;
     private final UUID FREELANCER_ID = UUID.randomUUID();
-    private FreelancerDTO inputFreelancerDTO;
+    private FreelancerDTO freelancerDTO;
     private Freelancer freelancerEntity;
+    private FreelancerDTO inputFreelancerDTO;
 
     @BeforeEach
     void setup() {
+        freelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
         inputFreelancerDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
         freelancerEntity = FreelancerTestDataFactory.createFreelancerEntity(FREELANCER_ID);
     }
@@ -94,7 +100,7 @@ class FreelancerProfileServiceImplTest {
                 .postalCode(freelancerEntity.getPostalCode())
                 .phoneNumber(freelancerEntity.getPhoneNumber())
                 .isAbcMember(freelancerEntity.getIsAbcMember())
-                .profilePhotoURL(freelancerEntity.getProfilePhotoURL())
+                .profilePhotoS3Key(freelancerEntity.getProfilePhotoS3Key())
                 .profileStatus(freelancerEntity.getProfileStatus())
                 // CategoriesDTO is NOT set here, as the service does it in a subsequent step
                 .build();
@@ -105,9 +111,9 @@ class FreelancerProfileServiceImplTest {
         Set<CategoryDTO> expectedResponseCategoryDTOs = inputFreelancerDTO.getCategoriesDTO();
         for (CategoryDTO catDTO : expectedResponseCategoryDTOs) {
             Category correspondingEntity = expectedPersistedCategories.stream()
-                .filter(e -> e.getCategoryId().equals(catDTO.getCategoryId()))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Mismatch between test DTO and Entity categories for mocking"));
+                    .filter(e -> e.getCategoryId().equals(catDTO.getCategoryId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Mismatch between test DTO and Entity categories for mocking"));
             doReturn(catDTO).when(modelMapper).map(correspondingEntity, CategoryDTO.class);
         }
 
@@ -279,7 +285,7 @@ class FreelancerProfileServiceImplTest {
         // Arrange
         // Use existing freelancer from setup()
         when(freelancerRepository.findById(FREELANCER_ID)).thenReturn(Optional.of(freelancerEntity));
-        
+
         // Mock categories
         Set<Category> categories = new HashSet<>();
         Set<Long> categoryIds = Set.of(1L, 2L); // Define categoryIds here
@@ -291,24 +297,24 @@ class FreelancerProfileServiceImplTest {
         }
         // Mock save operation
         when(freelancerRepository.save(any(Freelancer.class))).thenReturn(freelancerEntity);
-        
+
         // Mock DTO mapping
         FreelancerDTO expectedDTO = FreelancerTestDataFactory.createFreelancerDTO(FREELANCER_ID);
-        
+
         // Mock category DTO mapping
         Set<CategoryDTO> categoryDTOs = new HashSet<>();
         for (Category category : categories) {
             CategoryDTO categoryDTO = CategoryDTO.builder()
-                .categoryId(category.getCategoryId())
-                .category("Category " + category.getCategoryId())
-                .build();
+                    .categoryId(category.getCategoryId())
+                    .category("Category " + category.getCategoryId())
+                    .build();
             categoryDTOs.add(categoryDTO);
             doReturn(categoryDTO).when(modelMapper).map(eq(category), eq(CategoryDTO.class));
         }
-        
+
         // Set categories in the expected DTO
         expectedDTO.setCategoriesDTO(categoryDTOs);
-        
+
         // Mock final DTO mapping
         doReturn(expectedDTO).when(modelMapper).map(freelancerEntity, FreelancerDTO.class);
 
@@ -321,7 +327,7 @@ class FreelancerProfileServiceImplTest {
         assertNotNull(result.getCategoriesDTO());
         assertEquals(categories.size(), result.getCategoriesDTO().size());
         assertTrue(result.getCategoriesDTO().containsAll(categoryDTOs));
-        
+
         // Verify interactions
         verify(freelancerRepository).findById(FREELANCER_ID);
         for (Long categoryId : categoryIds) {

--- a/src/test/java/com/jobmatrix/serviceimpl/S3ServiceImplTest.java
+++ b/src/test/java/com/jobmatrix/serviceimpl/S3ServiceImplTest.java
@@ -1,0 +1,54 @@
+package com.jobmatrix.serviceimpl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import java.lang.reflect.Field;
+import java.net.URL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceImplTest {
+
+    @Mock
+    private S3Presigner mockS3Presigner;
+
+    @InjectMocks
+    private S3ServiceImpl s3ServiceImpl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Set the private bucketName using reflection
+        Field field = S3ServiceImpl.class.getDeclaredField("bucketName");
+        field.setAccessible(true);
+        field.set(s3ServiceImpl, "dummy-bucket");
+    }
+
+    @Test
+    void testGeneratePresignedUploadUrl() {
+
+        String fileName = "test.jpg";
+        String contentType = "image/jpeg";
+        URL expectedUrl = mock(URL.class);
+
+        PresignedPutObjectRequest mockPresignedPutObjectRequest = mock(PresignedPutObjectRequest.class);
+
+        when(mockPresignedPutObjectRequest.url()).thenReturn(expectedUrl);
+
+        when(mockS3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenReturn(mockPresignedPutObjectRequest);
+
+        URL result = s3ServiceImpl.generatePresignedUploadUrl(fileName, contentType);
+
+        assertEquals(expectedUrl, result);
+        verify(mockS3Presigner, times(1)).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+}

--- a/src/test/java/com/jobmatrix/test_utils/factory/FreelancerTestDataFactory.java
+++ b/src/test/java/com/jobmatrix/test_utils/factory/FreelancerTestDataFactory.java
@@ -37,7 +37,7 @@ public class FreelancerTestDataFactory {
                 .postalCode("560001")
                 .phoneNumber("+919876543210")
                 .isAbcMember(true)
-                .profilePhotoURL("https://example.com/profile.jpg")
+                .profilePhotoS3Key("profile_photos/" + freelancerId + ".jpg")
                 .educations(createEducationList(freelancerId))
                 .jobs(createJobList(freelancerId))
                 .certificates(createCertificateList(freelancerId))
@@ -62,7 +62,7 @@ public class FreelancerTestDataFactory {
                 .postalCode("560001")
                 .phoneNumber("+919876543210")
                 .isAbcMember(true)
-                .profilePhotoURL("https://example.com/profile.jpg")
+                .profilePhotoS3Key("profile_photos/" + freelancerId + ".jpg")
                 .educations(createEducationListDTO(freelancerId))
                 .jobs(createJobListDTO(freelancerId))
                 .certificates(createCertificateListDTO(freelancerId))
@@ -90,7 +90,7 @@ public class FreelancerTestDataFactory {
     private static List<Education> createEducationList(UUID freelancerId) {
         return Arrays.asList(
                 new Education(1L, "B.Tech", "Computer Science", "IIT Delhi", 2015, 2019, freelancerId,
-                              Timestamp.valueOf(LocalDateTime.now()), Timestamp.valueOf(LocalDateTime.now()),null)
+                        Timestamp.valueOf(LocalDateTime.now()), Timestamp.valueOf(LocalDateTime.now()),null)
         );
     }
 


### PR DESCRIPTION
[JMK:85](https://punjabskillsbank.atlassian.net/browse/JMK-85)

## 🚀 Feature: Generate Pre-signed URL for Profile Photo Upload and Create Freelancer Profile

### 📋 Description

This PR enables frontend clients to request a **pre-signed S3 URL** for uploading freelancer profile photos securely.

---

### ✅ Flow Summary

When a user hits **Submit** on the frontend:

1. A `GET` request is made to `PresignedUrlController` with:
   - `freelancerId`
   - `contentType` (e.g., `image/jpeg`, `image/png`)

2. The controller calls `FileService.generateProfilePhotoUrl(freelancerId, contentType)`.

3. Inside `FileService`:
   - The `contentType` is validated.
   - A unique S3 key is generated (e.g., `profile-photos/{freelancerId}.contentType`).
   - The method `S3Service.generatePresignedUploadUrl(s3Key, contentType)` is called.

4. Inside `S3Service`:
   - The AWS S3 Presigner is used to generate a pre-signed `PUT` URL using the given key and content type.
   - The URL is returned to the `FileService`.

5. `FileService` returns a `PresignedUrlResponse` containing:
   - `presignedUrl`
   - `s3Key`

6. The controller sends this response back to the frontend.

**Note:** Freelancer Profile creation logic is not changed.


